### PR TITLE
144439479:Implement admin should be able to manage 

### DIFF
--- a/server/controller/RolesController.js
+++ b/server/controller/RolesController.js
@@ -28,7 +28,84 @@ const RoleController = {
           }));
   },
 
- 
+  /**
+    * Get all roles
+    * Route: GET: /roles/
+    * @param {Object} req request object
+    * @param {Object} res response object
+    * @returns {void} no returns
+    */
+  getAllRoles(req, res) {
+    db.Roles
+      .findAll()
+      .then((roles) => {
+        res.status(200)
+        .send({
+          message: 'You have successfully retrieved all roles',
+          roles
+        });
+      });
+  },
+  /**
+    * Update roles
+    * Route: PUT: /roles/:id
+    * @param {Object} req request object
+    * @param {Object} res response object
+    * @returns {void} no returns
+    */
+  updateRole(req, res) {
+    req.roleInstance.update(req.body)
+      .then((updatedRole) => {
+        res.status(200)
+          .send({
+            message: 'This role has been updated',
+            updatedRole
+          });
+      })
+      .catch(error =>
+        res.status(400)
+          .send({
+            errorArray: Helper.errorArray(error)
+          }));
+  },
+
+  /**
+    * Delete a Role
+    * Route: DELETE: /roles/:id
+    * @param {Object} req request object
+    * @param {Object} res response object
+    * @returns {void} no returns
+    */
+  deleteRole(req, res) {
+    console.log(res, 'andelaaaa');
+    req.roleInstance.destroy()
+      .then((updatedRole) => {
+        res.status(200)
+          .send({
+            message: 'This role has been deleted',
+            updatedRole
+          });
+      });
+  },
+  /**
+   * retrieve -  return a role
+   * @param {Object}  request request object
+   * @param {Object}  response response object
+   * @returns {void} - returns void
+   */
+  getRoleById(req, res) {
+    db.Roles.findById(req.params.id)
+      .then((role) => {
+        if (!role) {
+          return res.status(404).send({
+            message: 'Role does not exists'
+          });
+        }
+        return res.status(200).send({
+          role
+        });
+      });
+  }
 };
 
 export default RoleController;


### PR DESCRIPTION
#### What does this PR do?
This PR add feature (route and controller) for an admin to be able to manage users roles and create other admins

#### Description of Task to be completed?
created end point for admin to be able to create other admin
authenticate if the route subscriber is an admin and give him access to upgrade or downgrade other admin's account

#### How should this be manually tested?
by

1) clone the repo
2) run npm start
3) the app starts at local-host 5000
4) visit this url on post man localhost:5000/users/login and login with your email and password(post request)
5) if login is successful, open a new tab on postman and hit this end point localhost:5000/users/admin with a push request to create new admin

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
Admin user should be able to manage roles

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A